### PR TITLE
Describe submitting from the outside of the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker run -d -h sandbox sequenceiq/spark:1.6.0 -d
 
 ## Versions
 ```
-Hadoop 2.6.0 and Apache Spark v1.6.0 on Centos 
+Hadoop 2.6.0 and Apache Spark v1.6.0 on Centos
 ```
 
 ## Testing
@@ -85,4 +85,17 @@ spark-submit \
 --executor-memory 1g \
 --executor-cores 1 \
 $SPARK_HOME/lib/spark-examples-1.6.0-hadoop2.6.0.jar
+```
+
+### Submitting from the outside of the container
+To use Spark from outside of the container it is necessary to set the YARN_CONF_DIR environment variable to directory with a configuration appropriate for the docker. The repository contains such configuration in the yarn-remote-client directory.
+
+```
+export YARN_CONF_DIR="`pwd`/yarn-remote-client"
+```
+
+Docker's HDFS can be accessed only by root. When submitting Spark applications from outside of the cluster, and from a user different than root, it is necessary to configure the HADOOP_USER_NAME variable so that root user is used.
+
+```
+export HADOOP_USER_NAME=root
 ```


### PR DESCRIPTION
There are two variables that have be set in order to submit
anything to Spark running in the cluster. None of them were
described in README.

Sources:
http://blog.sequenceiq.com/blog/2014/08/22/spark-submit-in-java/
http://spark.apache.org/docs/1.6.1/running-on-yarn.html