### PR TITLE
Fix documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker run -it -p 8088:8088 -p 8042:8042 -p 4040:4040 -h sandbox sequenceiq/spar
 ```
 or
 ```
-docker run -d -h sandbox sequenceiq/spark:1.6.0 -d
+docker run -d -h sandbox sequenceiq/spark:1.6.0
 ```
 
 ## Versions


### PR DESCRIPTION
This commit adds fix for docker run command. The -d shouldn't be provided at the end.